### PR TITLE
chore: add justfile and MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Adam Kostarelas
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/justfile
+++ b/justfile
@@ -1,0 +1,23 @@
+# List available commands
+default:
+    @just --list
+
+# Fetch the Hugo theme submodules (one-time after clone)
+[group("dev")]
+setup:
+    git submodule update --init --recursive
+
+# Serve the site locally with live reload
+[group("dev")]
+run:
+    hugo server
+
+# Build the minified production site to ./public (matches gh-pages.yml)
+[group("ship")]
+build:
+    hugo --minify
+
+# Remove generated build output
+[group("dev")]
+clean:
+    rm -rf public


### PR DESCRIPTION
## Summary

- Adds a `justfile` with the common dev tasks for this Hugo site: `setup` (init theme submodules), `run` (hugo server), `build` (`hugo --minify`, matching `gh-pages.yml`), and `clean`.
- Adds an MIT `LICENSE` (Copyright (c) 2026 Adam Kostarelas).

## Base branch

This PR targets **`dev`**, not `master` — `master` holds the generated build output published by the GitHub Pages workflow, so source changes belong on `dev`.

## Note on the fork

`adamXbot` has read-only access to this repo, so the branch is delivered from the fork `adamXbot/AdamXweb.github.io`. The fork exists only to deliver this PR and can be deleted after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
